### PR TITLE
Initial Vulkan allocator implementation

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@ const glfw = @import("mach-glfw");
 
 const vulkan = @import("vulkan/vulkan.zig");
 const VulkanContext = vulkan.Context;
+const VulkanAllocator = vulkan.Allocator;
 
 const window_title = "ft_minecraft";
 const window_width = 640;
@@ -54,6 +55,12 @@ pub fn main() !void {
     const fn_get_proc_addr = @as(vk.PfnGetInstanceProcAddr, @ptrCast(&glfw.getInstanceProcAddress));
     var vk_ctx = try VulkanContext.init(std.heap.page_allocator, fn_get_proc_addr, glfw_extensions, window);
     defer vk_ctx.deinit();
+
+    var vk_allocator = VulkanAllocator.init(.{
+        .context = &vk_ctx,
+        .allocator = std.heap.page_allocator,
+    });
+    defer vk_allocator.deinit();
 
     const max_updates_per_loop = 8;
     const fixed_time_step = 1.0 / 60.0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,10 +56,7 @@ pub fn main() !void {
     var vk_ctx = try VulkanContext.init(std.heap.page_allocator, fn_get_proc_addr, glfw_extensions, window);
     defer vk_ctx.deinit();
 
-    var vk_allocator = VulkanAllocator.init(.{
-        .context = &vk_ctx,
-        .allocator = std.heap.page_allocator,
-    });
+    var vk_allocator = VulkanAllocator.init(std.heap.page_allocator, &vk_ctx);
     defer vk_allocator.deinit();
 
     const max_updates_per_loop = 8;

--- a/src/vulkan/Context.zig
+++ b/src/vulkan/Context.zig
@@ -96,6 +96,24 @@ pub fn deinit(self: Self) void {
     self.instance.destroyInstance(null);
 }
 
+pub fn findMemoryType(self: Self, type_filter: u32, flags: vk.MemoryPropertyFlags) !u32 {
+    const properties = self.instance.getPhysicalDeviceMemoryProperties(self.physical_device);
+
+    for (0..properties.memory_type_count) |memory_type| {
+        if (type_filter & (@as(u32, 1) << @intCast(memory_type)) == 0) {
+            continue;
+        }
+
+        const property_flags = properties.memory_types[memory_type].property_flags;
+
+        if (flags.intersect(property_flags) == flags) {
+            return @intCast(memory_type);
+        }
+    }
+
+    return error.MemoryTypeNotFound;
+}
+
 fn initInstance(
     self: *Self,
     allocator: Allocator,

--- a/src/vulkan/allocator/DedicatedAllocator.zig
+++ b/src/vulkan/allocator/DedicatedAllocator.zig
@@ -1,0 +1,149 @@
+/// Dedicated memory allocator.
+const std = @import("std");
+const vk = @import("vulkan");
+const vka = @import("allocator.zig");
+const vulkan = @import("../vulkan.zig");
+
+const debug = std.debug;
+const mem = std.mem;
+
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const AllocationIndex = vka.AllocationIndex;
+const Self = @This();
+
+pub const Allocation = struct {
+    size: vk.DeviceSize,
+    memory: vk.DeviceMemory = vk.DeviceMemory.null_handle,
+    map_count: u32 = 0,
+    data: ?*anyopaque = null,
+};
+
+const Transaction = struct {
+    index: AllocationIndex,
+    index_kind: IndexKind,
+
+    const IndexKind = enum {
+        /// Using the next available index.
+        next,
+        /// Using an index from the free list.
+        freed,
+    };
+};
+
+allocator: mem.Allocator,
+context: *const vulkan.Context,
+allocations: ArrayListUnmanaged(Allocation) = ArrayListUnmanaged(Allocation).empty,
+freed_indices: ArrayListUnmanaged(AllocationIndex) = ArrayListUnmanaged(AllocationIndex).empty,
+next_index: AllocationIndex = @enumFromInt(0),
+
+pub fn init(allocator: mem.Allocator, context: *const vulkan.Context) Self {
+    return Self{
+        .allocator = allocator,
+        .context = context,
+    };
+}
+
+pub fn deinit(self: *Self) void {
+    self.allocations.deinit(self.allocator);
+    self.freed_indices.deinit(self.allocator);
+}
+
+pub fn allocate(
+    self: *Self,
+    requirements: vk.MemoryRequirements,
+    property_flags: vk.MemoryPropertyFlags,
+) !AllocationIndex {
+    const transaction = self.beginTransaction();
+
+    const memory_type = try self.context.findMemoryType(requirements.memory_type_bits, property_flags);
+
+    const allocate_info = vk.MemoryAllocateInfo{
+        .allocation_size = requirements.size,
+        .memory_type_index = memory_type,
+    };
+
+    const memory = try self.context.device.allocateMemory(&allocate_info, null);
+
+    const allocation = Allocation{
+        .size = requirements.size,
+        .memory = memory,
+    };
+
+    switch (transaction.index_kind) {
+        .next => try self.allocations.append(self.allocator, allocation),
+        .freed => self.getAllocationPtr(transaction.index).* = allocation,
+    }
+
+    self.commitTransaction(transaction);
+
+    return transaction.index;
+}
+
+pub fn free(self: *Self, index: AllocationIndex) void {
+    const allocation = self.getAllocationPtr(index);
+
+    debug.assert(allocation.memory != vk.DeviceMemory.null_handle);
+
+    self.context.device.freeMemory(allocation.memory, null);
+    allocation.* = .{ .size = 0 };
+
+    self.freed_indices.append(self.allocator, index) catch {
+        debug.print("vka: unable to append to dedicated allocations free indices, allocation will not be reused.", .{});
+    };
+}
+
+pub fn map(self: Self, index: AllocationIndex) !*anyopaque {
+    const allocation = self.getAllocationPtr(index);
+
+    if (allocation.map_count == 0) {
+        allocation.data = try self.context.device.mapMemory(allocation.memory, 0, vk.WHOLE_SIZE, .{});
+    }
+
+    allocation.map_count += 1;
+    debug.assert(allocation.data != null);
+
+    return allocation.data.?;
+}
+
+pub fn unmap(self: Self, index: AllocationIndex) void {
+    const allocation = self.getAllocationPtr(index);
+
+    if (allocation.map_count == 0) {
+        return;
+    }
+
+    allocation.map_count -= 1;
+
+    if (allocation.map_count == 0) {
+        self.context.device.unmapMemory(allocation.memory);
+    }
+}
+
+pub fn getAllocation(self: Self, index: AllocationIndex) Allocation {
+    return self.getAllocationPtr(index).*;
+}
+
+pub fn getAllocationPtr(self: Self, index: AllocationIndex) *Allocation {
+    debug.assert(@intFromEnum(index) < self.allocations.items.len);
+
+    return &self.allocations.items[@intFromEnum(index)];
+}
+
+fn beginTransaction(self: Self) Transaction {
+    var transaction: Transaction = undefined;
+
+    transaction.index_kind = .freed;
+    transaction.index = self.freed_indices.getLastOrNull() orelse blk: {
+        transaction.index_kind = .next;
+        break :blk self.next_index;
+    };
+
+    return transaction;
+}
+
+fn commitTransaction(self: *Self, transaction: Transaction) void {
+    switch (transaction.index_kind) {
+        .next => self.next_index.increment(),
+        .freed => _ = self.freed_indices.pop(),
+    }
+}

--- a/src/vulkan/allocator/allocator.zig
+++ b/src/vulkan/allocator/allocator.zig
@@ -1,0 +1,170 @@
+// TODO: Thread safety?
+
+const std = @import("std");
+const vk = @import("vulkan");
+const vulkan = @import("../vulkan.zig");
+
+const DedicatedAllocator = @import("DedicatedAllocator.zig");
+
+const mem = std.mem;
+const debug = std.debug;
+
+/// An index to an allocation.
+pub const AllocationIndex = enum(u31) {
+    _,
+
+    const Self = @This();
+
+    pub fn increment(self: *Self) void {
+        self.* = @enumFromInt(@intFromEnum(self.*) + 1);
+    }
+};
+
+/// Handle to an allocation.
+pub const Allocation = struct {
+    index: AllocationIndex,
+    kind: AllocationKind,
+};
+
+/// A buffer handle.
+pub const Buffer = struct {
+    vk_handle: vk.Buffer,
+    allocation: Allocation,
+};
+
+/// An image handle.
+pub const Image = struct {
+    vk_handle: vk.Image,
+    allocation: Allocation,
+};
+
+const AllocationKind = enum(u1) {
+    dedicated,
+    pooled,
+};
+
+pub const AllocatorCreateInfo = struct {
+    allocator: mem.Allocator,
+    context: *const vulkan.Context,
+};
+
+/// Vulkan allocator.
+pub const Allocator = struct {
+    allocator: mem.Allocator,
+    context: *const vulkan.Context,
+    dedicated: DedicatedAllocator,
+    // TODO: Pooled allocator
+
+    const Self = @This();
+
+    pub fn init(create_info: AllocatorCreateInfo) Self {
+        return Self{
+            .allocator = create_info.allocator,
+            .context = create_info.context,
+            .dedicated = DedicatedAllocator.init(create_info.allocator, create_info.context),
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.dedicated.deinit();
+    }
+
+    /// Creates a buffer and binds memory to it. Buffer should be destroyed with `Allocator.destroyBuffer`.
+    pub fn createBuffer(
+        self: *Self,
+        buffer_info: vk.BufferCreateInfo,
+        memory_property_flags: vk.MemoryPropertyFlags,
+    ) !Buffer {
+        const buffer = try self.context.device.createBuffer(&buffer_info, null);
+        errdefer self.context.device.destroyBuffer(buffer, null);
+
+        const memory_requirements = self.context.device.getBufferMemoryRequirements(buffer);
+
+        const allocation = try self.allocate(memory_requirements, memory_property_flags);
+        errdefer self.free(allocation);
+
+        const memory = self.getMemory(allocation);
+        try self.context.device.bindBufferMemory(buffer, memory, 0);
+
+        return .{
+            .vk_handle = buffer,
+            .allocation = allocation,
+        };
+    }
+
+    /// Destroys a buffer created with `Allocator.createBuffer`.
+    pub fn destroyBuffer(self: *Self, buffer: Buffer) void {
+        self.context.device.destroyBuffer(buffer.vk_handle, null);
+        self.free(buffer.allocation);
+    }
+
+    /// Creates an image and binds memory to it. Image should be destroyed with `Allocator.destroyImage`.
+    pub fn createImage(
+        self: *Self,
+        image_info: vk.ImageCreateInfo,
+        memory_propery_flags: vk.MemoryPropertyFlags,
+    ) !Image {
+        const image = try self.context.device.createImage(&image_info, null);
+        errdefer self.context.device.destroyImage(image, null);
+
+        const memory_requirements = self.context.device.getImageMemoryRequirements(image);
+
+        const allocation = try self.allocate(memory_requirements, memory_propery_flags);
+        errdefer self.free(allocation);
+
+        const memory = self.getMemory(allocation);
+        try self.context.device.bindImageMemory(image, memory, 0);
+
+        return .{
+            .vk_handle = image,
+            .allocation = allocation,
+        };
+    }
+
+    /// Destroys an image created with `Allocator.createImage`.
+    pub fn destroyImage(self: *Self, image: Image) void {
+        self.context.device.destroyImage(image.vk_handle, null);
+        self.free(image.allocation);
+    }
+
+    pub fn allocate(
+        self: *Self,
+        requirements: vk.MemoryRequirements,
+        property_flags: vk.MemoryPropertyFlags,
+    ) !Allocation {
+        const index = try self.dedicated.allocate(requirements, property_flags);
+
+        return .{ .index = index, .kind = .dedicated };
+    }
+
+    pub fn free(self: *Self, allocation: Allocation) void {
+        switch (allocation.kind) {
+            .dedicated => self.dedicated.free(allocation.index),
+            else => debug.panic("unimplemented", .{}),
+        }
+    }
+
+    /// Maps memory for the given allocation and returns a pointer to it.
+    pub fn map(self: Self, allocation: Allocation) !*anyopaque {
+        return switch (allocation.kind) {
+            .dedicated => try self.dedicated.map(allocation.index),
+            else => debug.panic("unimplemented", .{}),
+        };
+    }
+
+    /// Unmaps memory previously mapped with `Allocator.map`. Invalidates the mapped pointer.
+    pub fn unmap(self: Self, allocation: Allocation) void {
+        return switch (allocation.kind) {
+            .dedicated => self.dedicated.unmap(allocation.index),
+            else => debug.panic("unimplemented", .{}),
+        };
+    }
+
+    /// Returns the raw vk.DeviceMemory for the allocation. Avoid calling this if possible.
+    pub fn getMemory(self: Self, allocation: Allocation) vk.DeviceMemory {
+        return switch (allocation.kind) {
+            .dedicated => self.dedicated.getAllocation(allocation.index).memory,
+            else => debug.panic("unimplemented", .{}),
+        };
+    }
+};

--- a/src/vulkan/allocator/allocator.zig
+++ b/src/vulkan/allocator/allocator.zig
@@ -43,11 +43,6 @@ const AllocationKind = enum(u1) {
     pooled,
 };
 
-pub const AllocatorCreateInfo = struct {
-    allocator: mem.Allocator,
-    context: *const vulkan.Context,
-};
-
 /// Vulkan allocator.
 pub const Allocator = struct {
     allocator: mem.Allocator,
@@ -57,7 +52,12 @@ pub const Allocator = struct {
 
     const Self = @This();
 
-    pub fn init(create_info: AllocatorCreateInfo) Self {
+    pub const CreateInfo = struct {
+        allocator: mem.Allocator,
+        context: *const vulkan.Context,
+    };
+
+    pub fn init(create_info: CreateInfo) Self {
         return Self{
             .allocator = create_info.allocator,
             .context = create_info.context,

--- a/src/vulkan/allocator/allocator.zig
+++ b/src/vulkan/allocator/allocator.zig
@@ -52,16 +52,11 @@ pub const Allocator = struct {
 
     const Self = @This();
 
-    pub const CreateInfo = struct {
-        allocator: mem.Allocator,
-        context: *const vulkan.Context,
-    };
-
-    pub fn init(create_info: CreateInfo) Self {
+    pub fn init(allocator: mem.Allocator, context: *const vulkan.Context) Self {
         return Self{
-            .allocator = create_info.allocator,
-            .context = create_info.context,
-            .dedicated = DedicatedAllocator.init(create_info.allocator, create_info.context),
+            .allocator = allocator,
+            .context = context,
+            .dedicated = DedicatedAllocator.init(allocator, context),
         };
     }
 

--- a/src/vulkan/vulkan.zig
+++ b/src/vulkan/vulkan.zig
@@ -1,1 +1,4 @@
 pub const Context = @import("Context.zig");
+
+pub usingnamespace @import("allocator/allocator.zig");
+

--- a/src/vulkan/vulkan.zig
+++ b/src/vulkan/vulkan.zig
@@ -1,4 +1,3 @@
 pub const Context = @import("Context.zig");
 
 pub usingnamespace @import("allocator/allocator.zig");
-


### PR DESCRIPTION
### Summary
Minimum viable Vulkan allocator implementation with the intended API. This does not yet provide allocation pooling, but abstracts over the allocation process so that pooling can be added in a future PR with minimal or no changes to the API. The current dedicated allocation scheme will serve as the fallback allocation scheme later.

The utility methods `createImage` and `createBuffer`, can be used to create an image/buffer in a single call, while the allocator manages finding the memory type & binding memory to the resource.

Implementation also provides methods `map` and `unmap` for host mapping allocations. Mappings are internally reference counted by the allocator, this allows for multiple simultaneous mappings of the same block of memory, which will become important later with the pooled allocations.

The implementation is loosely modelled based on [VulkanMemoryAllocator](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/index.html).

### Usage Examples
```zig
const VulkanAllocator = vulkan.Allocator;

// Initialization
var vk_allocator = VulkanAllocator.init(std.heap.page_allocator, &vk_ctx);
defer vk_allocator.deinit();

// Creating a buffer
const buffer_info = vk.BufferCreateInfo {
    .size = 512,
    .usage = .{ .index_buffer_bit = true },
    .sharing_mode = .exclusive,
};
const memory_flags = vk.MemoryPropertyFlags { .host_coherent_bit = true, .host_visible_bit = true };
const buffer = try vk_allocator.createBuffer(buffer_info, memory_flags);
defer vk_allocator.destroyBuffer(buffer);

// Map/Unmap the allocation
const data_ptr = try vk_allocator.map(buffer.allocation);
defer vk_allocator.unmap(buffer.allocation);
_ = data_ptr;

// Creating an image
const image_info = vk.ImageCreateInfo {
    .sharing_mode = .exclusive,
    .usage = .{ .transfer_src_bit = true },
    .format = .r8g8b8a8_uint,
    .extent = .{
        .width = 512,
        .height = 512,
        .depth = 1,
    },
    .tiling = .linear,
    .samples = .{ .@"1_bit" = true },
    .image_type = .@"2d",
    .mip_levels = 1,
    .array_layers = 1,
    .initial_layout = .undefined,
};
const image_memory_flags = vk.MemoryPropertyFlags { .host_visible_bit = true, .host_coherent_bit = true };
const image = try vk_allocator.createImage(image_info, image_memory_flags);
defer vk_allocator.destroyImage(image);

// Accessing the raw vk.DeviceMemory associated with an allocation
// (should be avoided if any examples above are applicable)
const memory = vk_allocator.getMemory(image.allocation);
```